### PR TITLE
Allow recipient to be populated by msg variable

### DIFF
--- a/sms-send.js
+++ b/sms-send.js
@@ -15,7 +15,7 @@ module.exports = function(RED) {
                             'phoneNumber': node.credsNode.username
                         },
                         to: [
-                            {'phoneNumber': n.recipient}
+                            {'phoneNumber': msg.payload.recipient}
                         ],
                         text: msg.payload.toString()
                     })


### PR DESCRIPTION
Allow recipient to be populated via msg.payload.recipient variable.  One thing I'm not clear on is if it's possible to set multiple recipients via this method, so attempting to start with one recipient to begin with.